### PR TITLE
doc(auth): fixes doc in DataHubSystemAuthenticator.java

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubSystemAuthenticator.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubSystemAuthenticator.java
@@ -24,11 +24,6 @@ import static com.datahub.authentication.AuthenticationConstants.*;
  * This makes use of a single "system client id" and "system shared secret" which each
  * component in the system is configured to provide.
  *
- * This authenticator also looks for a "delegated actor urn" which can be provided by system callers using the 'X-DataHub-Actor'
- * header. This indicates that the system is making a request on behalf of an end-user with the specified URN. In the future, we intend
- * to additionally pass the original credentials provided by the Actor along with the request, along with the Actor Type in the event that
- * service principals are added as a new entity type.
- *
  * This authenticator requires the following configurations:
  *
  *  - systemClientId: an identifier for internal system callers, provided in the Authorization header via Basic Authentication.


### PR DESCRIPTION
DataHubSystemAuthenticator is not processing legacy `X-DataHub-Actor` header and so removing a comment that causes confusion.

Instead, the expected workflow is:

1. Request an access token for the session to the GMS by calling `generateSessionTokenForUser` in https://github.com/datahub-project/datahub/blob/ae30be9c25760ff53c8ef49724fcc177566db1fe/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java#L69-L87 Note this endpoint is restricted to "trusted" components only (system id authentication; that will be authenticated by the `DataHubSystemAuthenticator`)
2. Following requests from the "trusted" component will include the access token (so those requests will be authenticated by the `DataHubTokenAuthenticator`).


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
